### PR TITLE
New clustertest replication start

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -294,6 +294,9 @@ verify_ssl_certificates = false
 ;ssl_trusted_certificates_file = /etc/ssl/certs/ca-certificates.crt
 ; Maximum peer certificate depth (must be set even if certificate validation is off).
 ssl_certificate_max_depth = 3
+; improve testing
+start_delay=0
+start_splay=1
 
 [compaction_daemon]
 ; The delay, in seconds, between each check for which database and view indexes

--- a/test/javascript/replicator_db_inc.js
+++ b/test/javascript/replicator_db_inc.js
@@ -32,7 +32,7 @@ replicator_db.docs1 = [
   }
 ];
 
-replicator_db.waitForRep = function waitForSeq(repDb, repDoc, state) {
+replicator_db.waitForRep = function waitForSeq(repDb, repDoc, state, errorState) {
   var newRep,
       t0 = new Date(),
       t1,
@@ -41,7 +41,8 @@ replicator_db.waitForRep = function waitForSeq(repDb, repDoc, state) {
   do {
     newRep = repDb.open(repDoc._id);
     t1 = new Date();
-  } while (((t1 - t0) <= ms) && newRep._replication_state !== state);
+  } while (((t1 - t0) <= ms) && newRep._replication_state !== state && (!errorState || newRep._replication_state !== errorState));
+  return newRep ? newRep._replication_state : null;
 }
 
 replicator_db.waitForSeq = function waitForSeq(sourceDb, targetDb) {

--- a/test/javascript/tests/changes.js
+++ b/test/javascript/tests/changes.js
@@ -669,7 +669,7 @@ couchTests.changes = function(debug) {
   TEquals(2, resp.results.length);
 
   // we can no longer pass a number into 'since' - but we have the 2nd last above - so we can use it (puh!)
-  req = CouchDB.request("GET", "/" + db.name + "/_changes?style=all_docs&since=" + encodeURIComponent(JSON.stringify(resp.results[0].seq)));
+  req = CouchDB.request("GET", "/" + db.name + "/_changes?style=all_docs&since=" + encodeURIComponent(resp.results[0].seq));
   resp = JSON.parse(req.responseText);
 
   // (seq as before)
@@ -693,7 +693,7 @@ couchTests.changes = function(debug) {
 
   // simulate an EventSource request with a Last-Event-ID header
   req = CouchDB.request("GET", "/" + db_name + "/_changes?feed=eventsource&timeout=0&since=0",
-        {"headers": {"Accept": "text/event-stream", "Last-Event-ID": JSON.stringify(JSON.parse(req.responseText).results[1].seq)}});
+        {"headers": {"Accept": "text/event-stream", "Last-Event-ID": JSON.parse(req.responseText).results[1].seq}});
 
   // "parse" the eventsource response and collect only the "id: ..." lines
   var changes = req.responseText.split('\n')
@@ -703,10 +703,10 @@ couchTests.changes = function(debug) {
      .filter(function (el) { return (el[0] === "id"); })
 
   // make sure we only got 2 changes, and they are update_seq=3 and update_seq=4
-// TODO: can't pass in new-style Sequence with Last-Event-ID header
-//  T(changes.length === 2);
-//  T(changes[0][1] === "3");
-//  T(changes[1][1] === "4");
+  T(changes.length === 2);
+  // seq is different now
+  //T(changes[0][1] === "3");
+  //T(changes[1][1] === "4");
 
   // COUCHDB-1923
   // test w/ new temp DB

--- a/test/javascript/tests/compact.js
+++ b/test/javascript/tests/compact.js
@@ -11,7 +11,7 @@
 // the License.
 
 couchTests.compact = function(debug) {
-  return console.log('TODO');
+  return console.log('TODO: compaction not available on cluster');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
   db.createDb();

--- a/test/javascript/tests/config.js
+++ b/test/javascript/tests/config.js
@@ -11,7 +11,7 @@
 // the License.
 
 couchTests.config = function(debug) {
-  return console.log('TODO');
+  return console.log('TODO: config port not available on cluster');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
   db.createDb();

--- a/test/javascript/tests/cookie_auth.js
+++ b/test/javascript/tests/cookie_auth.js
@@ -12,7 +12,9 @@
 
 couchTests.cookie_auth = function(debug) {
   // This tests cookie-based authentication.
-  return console.log('TODO');
+  //return console.log('TODO');
+  // TODO: re-write so we get along withOUT changed config
+  // poss.: re-write so we just use _users and add some docs (and we delete those b4 running). Admin party should not hurt when logging in more
 
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/etags_views.js
+++ b/test/javascript/tests/etags_views.js
@@ -11,7 +11,7 @@
 // the License.
 
 couchTests.etags_views = function(debug) {
-  return console.log('TODO');
+  return console.log('TODO - see https://issues.apache.org/jira/browse/COUCHDB-2859');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"true"});
   db.createDb();

--- a/test/javascript/tests/replication.js
+++ b/test/javascript/tests/replication.js
@@ -1470,10 +1470,9 @@ couchTests.replication = function(debug) {
   };
   var bigTextAtt = makeAttData(128 * 1024);
   var attName = "readme.txt";
-  var xhr = CouchDB.request("GET", "/_config/attachments/compression_level");
-  var compressionLevel = JSON.parse(xhr.responseText);
-  xhr = CouchDB.request("GET", "/_config/attachments/compressible_types");
-  var compressibleTypes = JSON.parse(xhr.responseText);
+  var oldSettings = getCompressionInfo();
+  var compressionLevel = oldSettings.level;
+  var compressibleTypes = oldSettings.types;
 
   for (i = 0; i < dbPairs.length; i++) {
     populateDb(sourceDb, [doc]);

--- a/test/javascript/tests/replication.js
+++ b/test/javascript/tests/replication.js
@@ -543,12 +543,13 @@ couchTests.replication = function(debug) {
   docs = makeDocs(1, 6);
 
   for (i = 0; i < dbPairs.length; i++) {
-    var since_seq = 3;
     populateDb(sourceDb, docs);
     populateDb(targetDb, []);
+    // sequences are no longer simple numbers - so pull #3 from a feed
+    var since_seq = sourceDb.changes().results[2].seq;
 
     var expected_ids = [];
-    var changes = sourceDb.changes({since: since_seq});
+    var changes = sourceDb.changes({since: JSON.stringify(since_seq)});
     for (j = 0; j < changes.results.length; j++) {
       expected_ids.push(changes.results[j].id);
     }
@@ -566,7 +567,7 @@ couchTests.replication = function(debug) {
       );
     } catch (x) {
       // OTP R14B03 onwards
-      TEquals("not found", x.error);
+      TEquals("not_found", x.error);
     }
     repResult = CouchDB.replicate(
       dbPairs[i].source,
@@ -584,7 +585,7 @@ couchTests.replication = function(debug) {
       );
     } catch (x) {
       // OTP R14B03 onwards
-      TEquals("not found", x.error);
+      TEquals("not_found", x.error);
     }
     TEquals(true, repResult.ok);
     TEquals(2, repResult.history[0].missing_checked);

--- a/test/javascript/tests/replication.js
+++ b/test/javascript/tests/replication.js
@@ -11,7 +11,7 @@
 // the License.
 
 couchTests.replication = function(debug) {
-  return console.log('TODO');
+//  return console.log('TODO');
   if (debug) debugger;
 
   var host = CouchDB.host;
@@ -210,15 +210,17 @@ couchTests.replication = function(debug) {
     TEquals(sourceInfo.doc_count, targetInfo.doc_count);
 
     TEquals('string', typeof repResult.session_id);
-    TEquals(repResult.source_last_seq, sourceInfo.update_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals(repResult.source_last_seq, sourceInfo.update_seq);
     TEquals(true, repResult.history instanceof Array);
     TEquals(1, repResult.history.length);
     TEquals(repResult.history[0].session_id, repResult.session_id);
     TEquals('string', typeof repResult.history[0].start_time);
     TEquals('string', typeof repResult.history[0].end_time);
     TEquals(0, repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(sourceInfo.doc_count, repResult.history[0].missing_checked);
     TEquals(sourceInfo.doc_count, repResult.history[0].missing_found);
     TEquals(sourceInfo.doc_count, repResult.history[0].docs_read);
@@ -271,15 +273,17 @@ couchTests.replication = function(debug) {
     TEquals(targetInfo.doc_count, sourceInfo.doc_count);
 
     TEquals('string', typeof repResult.session_id);
-    TEquals(sourceInfo.update_seq, repResult.source_last_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals(sourceInfo.update_seq, repResult.source_last_seq);
     TEquals(true, repResult.history instanceof Array);
     TEquals(2, repResult.history.length);
     TEquals(repResult.history[0].session_id, repResult.session_id);
     TEquals('string', typeof repResult.history[0].start_time);
     TEquals('string', typeof repResult.history[0].end_time);
-    TEquals((sourceInfo.update_seq - 6), repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals((sourceInfo.update_seq - 6), repResult.history[0].start_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(6, repResult.history[0].missing_checked);
     TEquals(6, repResult.history[0].missing_found);
     TEquals(6, repResult.history[0].docs_read);
@@ -339,9 +343,10 @@ couchTests.replication = function(debug) {
 
     TEquals(true, repResult.history instanceof Array);
     TEquals(3, repResult.history.length);
-    TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(1, repResult.history[0].missing_checked);
     TEquals(1, repResult.history[0].missing_found);
     TEquals(1, repResult.history[0].docs_read);
@@ -352,9 +357,13 @@ couchTests.replication = function(debug) {
     TEquals(null, copy);
 
     var changes = targetDb.changes({since: 0});
-    var idx = changes.results.length - 1;
-    TEquals(docs[1]._id, changes.results[idx].id);
-    TEquals(true, changes.results[idx].deleted);
+    // there is no guarantee of ordering also
+    // however: the doc has to appear somewhere
+    //var idx = changes.results.length - 1;
+    var changesResDoc1 = changes.results.filter(function(c){return c.id == docs[1]._id;});
+    TEquals(1, changesResDoc1.length);
+    TEquals(docs[1]._id, changesResDoc1[0].id);
+    TEquals(true, changesResDoc1[0].deleted);
 
     // test conflict
     doc = sourceDb.open(docs[0]._id);
@@ -375,9 +384,10 @@ couchTests.replication = function(debug) {
 
     TEquals(true, repResult.history instanceof Array);
     TEquals(4, repResult.history.length);
-    TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(1, repResult.history[0].missing_checked);
     TEquals(1, repResult.history[0].missing_found);
     TEquals(1, repResult.history[0].docs_read);
@@ -405,9 +415,10 @@ couchTests.replication = function(debug) {
 
     TEquals(true, repResult.history instanceof Array);
     TEquals(5, repResult.history.length);
-    TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(1, repResult.history[0].missing_checked);
     TEquals(1, repResult.history[0].missing_found);
     TEquals(1, repResult.history[0].docs_read);
@@ -438,9 +449,10 @@ couchTests.replication = function(debug) {
 
     TEquals(true, repResult.history instanceof Array);
     TEquals(6, repResult.history.length);
-    TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals((sourceInfo.update_seq - 1), repResult.history[0].start_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(1, repResult.history[0].missing_checked);
     TEquals(1, repResult.history[0].missing_found);
     TEquals(1, repResult.history[0].docs_read);
@@ -463,10 +475,11 @@ couchTests.replication = function(debug) {
     TEquals(true, repResult.ok);
 
     sourceInfo = sourceDb.info();
-    TEquals(sourceInfo.update_seq, repResult.source_last_seq);
-    TEquals(sourceInfo.update_seq - 3, repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals(sourceInfo.update_seq, repResult.source_last_seq);
+    //TEquals(sourceInfo.update_seq - 3, repResult.history[0].start_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(3, repResult.history[0].missing_checked);
     TEquals(1, repResult.history[0].missing_found);
     TEquals(1, repResult.history[0].docs_read);
@@ -482,10 +495,11 @@ couchTests.replication = function(debug) {
     TEquals(true, repResult.ok);
 
     sourceInfo = sourceDb.info();
-    TEquals(sourceInfo.update_seq, repResult.source_last_seq);
-    TEquals(sourceInfo.update_seq - 2, repResult.history[0].start_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
-    TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals(sourceInfo.update_seq, repResult.source_last_seq);
+    //TEquals(sourceInfo.update_seq - 2, repResult.history[0].start_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].end_last_seq);
+    //TEquals(sourceInfo.update_seq, repResult.history[0].recorded_seq);
     TEquals(2, repResult.history[0].missing_checked);
     TEquals(0, repResult.history[0].missing_found);
     TEquals(0, repResult.history[0].docs_read);
@@ -496,7 +510,8 @@ couchTests.replication = function(debug) {
     TEquals(true, repResult.ok);
     TEquals(true, repResult.no_changes);
     sourceInfo = sourceDb.info();
-    TEquals(sourceInfo.update_seq, repResult.source_last_seq);
+    // we can't rely on sequences in a cluster
+    //TEquals(sourceInfo.update_seq, repResult.source_last_seq);
   }
 
 

--- a/test/javascript/tests/replicator_db_bad_rep_id.js
+++ b/test/javascript/tests/replicator_db_bad_rep_id.js
@@ -31,8 +31,9 @@ couchTests.replicator_db_bad_rep_id = function(debug) {
 
     var repDoc = {
       _id: "foo_rep",
-      source: dbA.name,
-      target: dbB.name,
+// TODO: fix DB name issue and remove absolute URL again
+      source: 'http://localhost:15984/'+dbA.name,
+      target: 'http://localhost:15984/'+dbB.name,
       replication_id: "1234abc"
     };
     T(replDb.save(repDoc).ok);
@@ -77,9 +78,9 @@ couchTests.replicator_db_bad_rep_id = function(debug) {
     var replDoc = replDb.open("foo_rep");
     if(replDoc!=null) {
       if(show) {
-        console.log(JSON.stringify(replDoc));
+        //console.log(JSON.stringify(replDoc));
       }
-      //replDb.deleteDoc(replDoc);
+      replDb.deleteDoc(replDoc);
     }
   }
 


### PR DESCRIPTION
Don't know where the huge diff comes from - certainly makes sense to cherry-pick only the LAST commit (it's the only one containing actual work). Or let me know what I can do ;-)

Anyway: here's a solution to work w/out _config (if we want to stick 2 that): add docs to _replicator and remove them again. Also set thresholds down. Resulted in COUCHDB-2869

Once we have decided (would be a question to @janl or @kxepal) whether or not to use _config we can fix most of the repl*.js tests similarly I guess

Good night ;-)
